### PR TITLE
Update API for `center_on` to match implementation

### DIFF
--- a/minimum_viable_imagewidget.py
+++ b/minimum_viable_imagewidget.py
@@ -45,9 +45,11 @@ class ImageWidget:
         *intentional* - the user should create an `nddata` if they want wcs.
         """
 
-    def center_on(self, x, y):
+    def center_on(self, point):
         """
         Centers the view on a particular point
+        
+        ``point`` can either be an (x, y) pixel pair or a SkyCoord object.
         """
 
     def offset_to(self, dx, dy):


### PR DESCRIPTION
The implemented API is a little more convenient than two separate arguments would be, especially when the point on which to center is a `SkyCoord`. This pattern is really convenient: `ImageWidget.center_on(SkyCoord.from_name('kelt-16'))`