### PR TITLE
Change default value of clear_marks

### DIFF
--- a/minimum_viable_imagewidget.py
+++ b/minimum_viable_imagewidget.py
@@ -92,7 +92,7 @@ class ImageWidget:
         object.
         """
 
-    def stop_selecting(self, clear_marks=True):
+    def stop_selecting(self, clear_marks=False):
         """
         Just what it says on the tin.
 


### PR DESCRIPTION
If this defaults to `True` then the eminently sensible seeming sequence 

```python
ImageWidget.start_marking()
# Click on the image in here, adding markers
ImageWidget.stop_marking()
```

results in the markers being wiped when marking is stopped. Having the optoin to wipe markers when you stop (as in "oops, messed up, let's just wipe them") makes a lot of sense. 